### PR TITLE
feat: 로그아웃 및 로그인 결과값 반영

### DIFF
--- a/src/api/auth/loginApi.ts
+++ b/src/api/auth/loginApi.ts
@@ -8,6 +8,7 @@ interface LoginApiProps {
 
 interface LoginApiReturn {
   isMentor: boolean;
+  nickname: string;
 }
 
 const loginApi = ({ ...elem }: LoginApiProps): Promise<LoginApiReturn> => axiosCase(client.post('/api/v1/auth/login', { ...elem }));

--- a/src/api/auth/logoutApi.ts
+++ b/src/api/auth/logoutApi.ts
@@ -1,0 +1,6 @@
+import client from '../common/client';
+import axiosCase from '../common/promiseCase';
+
+const logoutApi = () => axiosCase(client.post('/api/v1//auth/logout'));
+
+export default logoutApi;

--- a/src/layout/Header/index.tsx
+++ b/src/layout/Header/index.tsx
@@ -1,3 +1,4 @@
+import logoutApi from '@/api/auth/logoutApi';
 import currentUserAtom from '@/recoil/user/currentUserAtom';
 import cls from '@/utils/cls';
 import Link from 'next/link';
@@ -28,8 +29,12 @@ export default function Header() {
   const onLogoClick = () => router.push('/');
   const onLoginClick = () => router.push('/login');
   const onMyPageClick = () => router.push('/mypage');
-  const onLogout = () => {
+  const onLogout = async () => {
+    await logoutApi();
     setCurrentUser(null);
+    //mocking용 추후 지워야 하는 부분
+    localStorage.removeItem('email');
+    //
     router.replace('/');
   };
 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -28,7 +28,11 @@ const Login = () => {
   const onSubmit = async (data: LoginForm) => {
     try {
       const loginResult = await loginMutate(data);
-      setCurrentUser({ isInformer: loginResult.isMentor, nickName: 'gugu' });
+      console.log(loginResult);
+      setCurrentUser({ isInformer: loginResult.isMentor, nickName: loginResult.nickname });
+      // mocking용 추후 지워야 하는 부분
+      localStorage.setItem('email', data.email);
+      //
       router.push('/');
     } catch (errorCode) {
       setServerError(getErrorMessage(errorCode as string));


### PR DESCRIPTION
### Motivate

저희 인증이 httpOnly 쿠키에 JWT 토큰을 발급하는 형태라 로그아웃을 서버에게 요청을 보내야함.
로그인하고 난 이후 나온 결과값으로 프론트엔드 화면 구성

### key Change

* 꼭 연결을 확인하는 API를 판 이후에 이걸로 연결 상태를 확인하자 (로컬 스토리지로 연결을 확신하는 행위는 API를 쏘기 직전까지 권한이 만료되었다는 걸 모르게 한다. )
* 연결만 확인 된다면 localStorage 값을 이용해도 괜찮을 듯 싶다. (인증 에러 났을 때나 로그아웃 했을 때 localStorage만 잘 비워주면 괜찮을 것 같다. )